### PR TITLE
Rework error propagation and asyncify more operations

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,25 @@ jobs:
 rust:
   - stable
 
+before_script:
+  - |
+    if [[ "$TRAVIS_RUST_VERSION" == stable && "$TRAVIS_OS_NAME" = "linux" ]]; then
+      bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh)
+      rustup component add clippy
+      rustup component add rustfmt
+      cargo fmt -- --check
+      cargo clippy --all --bins --examples --tests --benches -- -Wclippy::all -Dwarnings
+    fi
+
 script:
   - cargo test
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash <(curl https://raw.githubusercontent.com/xd009642/tarpaulin/master/travis-install.sh); fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cargo tarpaulin --out Xml              ; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then bash <(curl -s https://codecov.io/bash); fi
+
+after_success:
+  - |
+    if [[ "$TRAVIS_RUST_VERSION" == stable && "$TRAVIS_OS_NAME" = "linux" ]]; then
+      cargo tarpaulin --out Xml
+      bash <(curl -s https://codecov.io/bash)
+    fi
 
 cache:
   cargo: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ async-trait = "0.1"
 futures-util = "0.3"
 notify = "5.0.0-pre.2"
 pin-project-lite = "0.1"
-thiserror = "1.0"
 tokio = { version = "=0.2.13", features = ["fs", "io-util", "macros", "stream", "sync", "time"] }
 
 [dev-dependencies]

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -12,16 +12,18 @@ use tokio;
 use linemux::MuxedEvents;
 
 #[tokio::main(threaded_scheduler)]
-pub async fn main() {
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
-    let mut events = MuxedEvents::new();
+    let mut events = MuxedEvents::new()?;
 
     for f in args {
-        events.add_file(&f).unwrap();
+        events.add_file(&f)?;
     }
 
-    while let Some(event) = events.next().await {
+    while let Some(Ok(event)) = events.next().await {
         println!("event: {:?}", event)
     }
+
+    Ok(())
 }

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -14,16 +14,16 @@ use tokio;
 use linemux::MuxedLines;
 
 #[tokio::main(threaded_scheduler)]
-pub async fn main() {
+pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
-    let mut events = MuxedLines::new();
+    let mut events = MuxedLines::new()?;
 
     for f in args {
-        events.add_file(&f).await.unwrap();
+        events.add_file(&f).await?;
     }
 
-    while let Some(lineset) = events.next().await {
+    while let Some(Ok(lineset)) = events.next().await {
         let source = lineset.source().display();
 
         for line in lineset.iter() {
@@ -32,4 +32,6 @@ pub async fn main() {
 
         tokio::time::delay_for(Duration::from_secs(1)).await;
     }
+
+    Ok(())
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -170,11 +170,18 @@ impl MuxedEvents {
 
         // TODO: properly handle any errors encountered adding/removing stuff
         paths.retain(|path| {
-            if path.exists() && self.pending_watched_files.contains(path) {
-                // TODO: should only do on events that imply file exists
+            let path_exists = path.exists();
+
+            // TODO: could be more intelligent/performant by checking event types
+            if path_exists && self.pending_watched_files.contains(path) {
                 let parent = path.parent().expect("Pending watched file needs a parent");
                 let _ = self.remove_directory(parent);
                 self.pending_watched_files.remove(path);
+                let _ = self.add_file(path);
+            }
+
+            if !path_exists && self.watched_files.contains(path) {
+                self.watched_files.remove(path);
                 let _ = self.add_file(path);
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! # use std::path::Path;
 //! #
 //! # async fn dox() -> io::Result<()> {
-//! let mut lines = MuxedLines::new();
+//! let mut lines = MuxedLines::new()?;
 //!
 //! // Register some files to be tailed, whether they currently exist or not.
 //! lines.add_file("some/file.log").await?;
@@ -20,7 +20,7 @@
 //!
 //! // Wait for `LineSet` event, which contains a batch of lines captured for a
 //! // given source path.
-//! while let Some(lineset) = lines.next().await {
+//! while let Some(Ok(lineset)) = lines.next().await {
 //!     let source = lineset.source().display();
 //!
 //!     for line in lineset.iter() {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -424,7 +424,7 @@ mod tests {
         assert_eq!(line_slice, lines.as_slice());
 
         assert_eq!(lineset.len(), lines.len());
-        assert_eq!(lineset.iter().collect::<Vec<&String>>().len(), lines.len());
+        assert_eq!(lineset.iter().count(), lines.len());
         assert!(!lineset.is_empty());
 
         let (source_de, lines_de) = lineset.into_inner();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,7 +1,7 @@
 //! Everything related to reading lines for a given event.
 
 use std::collections::{HashMap, HashSet};
-use std::fs::metadata as std_metadata;
+use std::fmt;
 use std::io;
 use std::iter::IntoIterator;
 use std::path::{Path, PathBuf};
@@ -10,26 +10,22 @@ use std::slice::Iter;
 use std::future::Future;
 use std::task;
 
+use futures_util::ready;
 use futures_util::stream::{Stream as FuturesStream, StreamExt};
-use futures_util::{pin_mut, ready};
 use pin_project_lite::pin_project;
-use tokio::fs::File;
+use tokio::fs::{metadata, File};
 use tokio::io::{AsyncBufReadExt, BufReader, Lines};
 
 use std::pin::Pin;
 
 type LineReader = Lines<BufReader<File>>;
 
-fn new_linereader(path: impl AsRef<Path>, seek_pos: Option<u64>) -> io::Result<LineReader> {
-    use std::fs::File as StdFile;
-    use std::io::{Seek, SeekFrom};
-
+async fn new_linereader(path: impl AsRef<Path>, seek_pos: Option<u64>) -> io::Result<LineReader> {
     let path = path.as_ref();
-    let mut reader = StdFile::open(path)?;
+    let mut reader = File::open(path).await?;
     if let Some(pos) = seek_pos {
-        reader.seek(SeekFrom::Start(pos)).unwrap();
+        reader.seek(io::SeekFrom::Start(pos)).await?;
     }
-    let reader = File::from_std(reader);
     let reader = BufReader::new(reader).lines();
 
     Ok(reader)
@@ -125,6 +121,43 @@ impl IntoIterator for LineSet {
     }
 }
 
+struct Inner {
+    reader_positions: HashMap<PathBuf, u64>,
+    readers: HashMap<PathBuf, LineReader>,
+    pending_readers: HashSet<PathBuf>,
+}
+
+impl Inner {
+    pub fn new() -> Self {
+        Inner {
+            reader_positions: HashMap::new(),
+            readers: HashMap::new(),
+            pending_readers: HashSet::new(),
+        }
+    }
+
+    pub fn reader_exists(&self, path: &PathBuf) -> bool {
+        // Make sure there isn't already a reader for the file
+        self.readers.contains_key(path) || self.pending_readers.contains(path)
+    }
+
+    pub fn insert_pending(&mut self, path: PathBuf) -> bool {
+        self.pending_readers.insert(path)
+    }
+
+    pub fn remove_pending(&mut self, path: &PathBuf) -> bool {
+        self.pending_readers.remove(path)
+    }
+
+    pub fn insert_reader(&mut self, path: PathBuf, reader: LineReader) -> Option<LineReader> {
+        self.readers.insert(path, reader)
+    }
+
+    pub fn insert_reader_position(&mut self, path: PathBuf, pos: u64) -> Option<u64> {
+        self.reader_positions.insert(path, pos)
+    }
+}
+
 pin_project! {
 /// Manages file watches, and can be polled to receive new lines.
 ///
@@ -145,9 +178,7 @@ pin_project! {
 pub struct MuxedLines {
     #[pin]
     events: crate::MuxedEvents,
-    reader_positions: HashMap<PathBuf, u64>,
-    readers: HashMap<PathBuf, LineReader>,
-    pending_readers: HashSet<PathBuf>,
+    inner: Option<Inner>,
     stream_state: StreamState,
 }
 }
@@ -156,16 +187,14 @@ impl MuxedLines {
     pub fn new() -> io::Result<Self> {
         Ok(MuxedLines {
             events: crate::MuxedEvents::new()?,
-            reader_positions: HashMap::new(),
-            readers: HashMap::new(),
-            pending_readers: HashSet::new(),
+            inner: Some(Inner::new()),
             stream_state: StreamState::default(),
         })
     }
 
     fn reader_exists(&self, path: &PathBuf) -> bool {
         // Make sure there isn't already a reader for the file
-        self.readers.contains_key(path) || self.pending_readers.contains(path)
+        self.inner.as_ref().unwrap().reader_exists(path)
     }
 
     /// Adds a given file to the lines watch, allowing for files which do not
@@ -184,18 +213,18 @@ impl MuxedLines {
         }
 
         if !source.exists() {
-            let didnt_exist = self.pending_readers.insert(source.clone());
+            let didnt_exist = self.inner.as_mut().unwrap().insert_pending(source.clone());
 
             // If this fails it's a bug
             assert!(didnt_exist);
         } else {
-            let size = std_metadata(&source)?.len();
+            let size = metadata(&source).await?.len();
 
-            let reader = new_linereader(&source, Some(size))?;
+            let reader = new_linereader(&source, Some(size)).await?;
 
-            self.reader_positions.insert(source.clone(), size);
-
-            let last = self.readers.insert(source.clone(), reader);
+            let inner_mut = self.inner.as_mut().unwrap();
+            inner_mut.insert_reader_position(source.clone(), size);
+            let last = inner_mut.insert_reader(source.clone(), reader);
 
             // If this fails it's a bug
             assert!(last.is_none());
@@ -206,10 +235,11 @@ impl MuxedLines {
     }
 }
 
-#[derive(Clone, Debug)]
+type HandleEventFuture = Pin<Box<dyn Future<Output = (Inner, Option<io::Result<()>>)>>>;
+
 enum StreamState {
     Events,
-    HandleEvent(notify::Event),
+    HandleEvent(notify::Event, HandleEventFuture),
     ReadLineSets(Vec<PathBuf>, Vec<String>),
 }
 
@@ -223,18 +253,27 @@ impl StreamState {
     }
 }
 
+impl fmt::Debug for StreamState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            StreamState::Events => write!(f, "Events"),
+            StreamState::HandleEvent(ref event, _) => {
+                write!(f, "HandleEvent({:?}, <elided>)", event)
+            }
+            StreamState::ReadLineSets(ref paths, ref lines) => {
+                write!(f, "ReadLineSets({:?}, {:?})", paths, lines)
+            }
+        }
+    }
+}
+
 impl Default for StreamState {
     fn default() -> Self {
         StreamState::Events
     }
 }
 
-fn handle_event_internal(
-    event: &notify::Event,
-    readers: &mut HashMap<PathBuf, LineReader>,
-    reader_positions: &mut HashMap<PathBuf, u64>,
-    pending_readers: &mut HashSet<PathBuf>,
-) -> Option<io::Result<()>> {
+async fn handle_event(event: notify::Event, mut inner: Inner) -> (Inner, Option<io::Result<()>>) {
     // TODO: This should return a PathBuf
 
     match &event.kind {
@@ -245,19 +284,19 @@ fn handle_event_internal(
                 (_, notify::event::CreateKind::File) => {}
                 (true, notify::event::CreateKind::Any) => {}
                 (_, _) => {
-                    return None;
+                    return (inner, None);
                 }
             }
 
             for path in &event.paths {
-                let _present = pending_readers.remove(path);
+                let _preset = inner.remove_pending(path);
 
                 // TODO: Handle error for each failed path
-                let reader = unwrap_res_or_continue!(new_linereader(path, None));
+                let reader = unwrap_res_or_continue!(new_linereader(path, None).await);
 
                 // Don't really care about old values, we got create
-                let _previous_reader = readers.insert(path.clone(), reader);
-                let _previous_pos = reader_positions.insert(path.clone(), 0);
+                let _previous_reader = inner.insert_reader(path.clone(), reader);
+                let _previous_pos = inner.insert_reader_position(path.clone(), 0);
             }
         }
 
@@ -268,16 +307,17 @@ fn handle_event_internal(
                 (_, notify::event::ModifyKind::Data(_)) => {}
                 (true, notify::event::ModifyKind::Any) => {}
                 (_, _) => {
-                    return None;
+                    return (inner, None);
                 }
             }
 
             // TODO: Currently assumes entry exists in `readers` for given path
 
             for path in &event.paths {
-                let size = unwrap_res_or_continue!(std_metadata(path)).len();
+                let size = unwrap_res_or_continue!(metadata(path).await).len();
 
-                let pos = reader_positions
+                let pos = inner
+                    .reader_positions
                     .get_mut(path)
                     .expect("missing reader position");
 
@@ -285,9 +325,9 @@ fn handle_event_internal(
                     // rolled
                     *pos = 0;
 
-                    let reader = unwrap_res_or_continue!(new_linereader(path, None));
+                    let reader = unwrap_res_or_continue!(new_linereader(path, None).await);
 
-                    let _previous_reader = readers.insert(path.clone(), reader);
+                    let _previous_reader = inner.insert_reader(path.clone(), reader);
                 } else {
                     // didn't roll, just update size
                     *pos = size;
@@ -296,14 +336,10 @@ fn handle_event_internal(
         }
 
         // Ignored event that doesn't warrant reading files
-        _ => return None,
+        _ => return (inner, None),
     }
 
-    Some(Ok(()))
-}
-
-async fn next_line_internal(reader: &mut LineReader) -> Option<io::Result<String>> {
-    reader.next().await
+    (inner, Some(Ok(())))
 }
 
 impl FuturesStream for MuxedLines {
@@ -316,9 +352,7 @@ impl FuturesStream for MuxedLines {
         let this = self.project();
 
         let mut events = this.events;
-        let reader_positions = this.reader_positions;
-        let readers = this.readers;
-        let pending_readers = this.pending_readers;
+        let inner = this.inner;
         let stream_state = this.stream_state;
 
         loop {
@@ -327,11 +361,16 @@ impl FuturesStream for MuxedLines {
                     let event = unwrap_res_or_continue!(unwrap_or_continue!(ready!(
                         events.poll_next_unpin(cx)
                     )));
-                    (StreamState::HandleEvent(event), None)
+                    // Temporarily take the inner reader context so that it can
+                    // be modified within async/await Future.
+                    let inner_taken = inner.take().expect("There was no inner to take");
+                    let fut = Box::pin(handle_event(event.clone(), inner_taken));
+                    (StreamState::HandleEvent(event, fut), None)
                 }
-                StreamState::HandleEvent(ref mut event) => {
-                    let res =
-                        handle_event_internal(&event, readers, reader_positions, pending_readers);
+                StreamState::HandleEvent(ref mut event, ref mut fut) => {
+                    let (inner_taken, res) = ready!(Pin::new(&mut *fut).poll(cx));
+                    let _isnone = inner.replace(inner_taken);
+                    assert!(_isnone.is_none());
 
                     match res {
                         Some(Ok(())) => {
@@ -347,10 +386,9 @@ impl FuturesStream for MuxedLines {
                 }
                 StreamState::ReadLineSets(paths, ref mut lines) => {
                     if let Some(path) = paths.get(0).cloned() {
-                        if let Some(reader) = readers.get_mut(&path.clone()) {
-                            let fut = next_line_internal(reader);
-                            pin_mut!(fut);
-                            let res = ready!(fut.poll(cx));
+                        if let Some(reader) = inner.as_mut().unwrap().readers.get_mut(&path.clone())
+                        {
+                            let res = ready!(Pin::new(reader).poll_next(cx));
 
                             match res {
                                 Some(Ok(line)) => {
@@ -467,7 +505,7 @@ mod tests {
         // Registering the same path again should be fine
         lines.add_file(&file_path2).await.unwrap();
 
-        assert_eq!(lines.pending_readers.len(), 2);
+        assert_eq!(lines.inner.as_ref().unwrap().pending_readers.len(), 2);
 
         let mut _file1 = File::create(&file_path1)
             .await
@@ -485,7 +523,7 @@ mod tests {
         );
 
         // Now the files should be readable
-        assert_eq!(lines.readers.len(), 2);
+        assert_eq!(lines.inner.as_ref().unwrap().readers.len(), 2);
         //assert!(!lines.watched_directories.contains_key(&pathclone));
 
         _file1.write_all(b"foo\n").await.unwrap();


### PR DESCRIPTION
**`Rework error propagation`**

Replaces all custom error types with `std::io::Error`, and expands error
propagation in more places, like `notify::Watcher` creation as well as
possible io errors encountered with watching events or reading lines.

**`event: replace async Future polling with Poll`**

Since `&mut self` is required after polling to manage its internal
state, `Unpin` is utilized to dereference self and individually pin the
event stream for polling.

**`reader: rework handling events to be asynchronous`**

Pushes the `*reader*` maps into an `Inner` structure which is
temporarily taken by async fn `handle_event` so that it can be polled in
the `impl Stream` as an anonymous Future.

This forgoes the original plan to implement the entire state machine by
hand, to prevent having to shovel and box memory on every iteration.
However, the `tokio::fs` operations introduce too many variants to the
state to be practical, so boxing the Future here is a reasonable
tradeoff.

Also, nuke `next_line_internal` in favor of just polling the reader
directly, to avoid dropping a Future on every iteration.
