### PR TITLE
Cleanup docs and deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,10 @@ license = "MIT OR Apache-2.0"
 categories = ["asynchronous", "filesystem"]
 
 [dependencies]
-async-trait = "0.1"
 futures-util = "0.3"
 notify = "5.0.0-pre.2"
 pin-project-lite = "0.1"
-tokio = { version = "=0.2.13", features = ["fs", "io-util", "macros", "stream", "sync", "time"] }
+tokio = { version = "0.2", features = ["fs", "io-util", "macros", "stream", "sync", "time"] }
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["tail", "lines", "watch", "fs", "events"]
 license = "MIT OR Apache-2.0"
 categories = ["asynchronous", "filesystem"]
 
+[badges]
+travis-ci = { repository = "jmagnuson/linemux", branch = "master" }
+codecov = { repository = "jmagnuson/linemux", branch = "master", service = "github" }
+
 [dependencies]
 futures-util = "0.3"
 notify = "5.0.0-pre.2"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 
 # linemux
 
+[![Build Status](https://travis-ci.com/jmagnuson/linemux.svg?branch=master)](https://travis-ci.com/jmagnuson/linemux)
+[![Crate](https://img.shields.io/crates/v/linemux.svg)](https://crates.io/crates/linemux)
+[![API](https://docs.rs/linemux/badge.svg)](https://docs.rs/linemux)
+[![Coverage](https://codecov.io/gh/jmagnuson/linemux/branch/master/graph/badge.svg)](https://codecov.io/gh/jmagnuson/linemux)
+
 A library providing asynchronous, multiplexed tailing for (namely log) files.
 
 Also available is the underlying file event-stream (driven by [`notify`](https://crates.io/crates/notify))
@@ -48,3 +53,19 @@ at least exist to register a directory watch with `notify`. This is done for
 performance reasons and to simplify the pending-watch complexity (such as
 limiting recursion and fs event spam). However, this may change if a need
 presents itself.
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  https://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -18,19 +18,25 @@ linemux = "0.1"
 ## Example
 
 ```rust,no_run
-let mut lines = MuxedLines::new();
+use linemux::MuxedLines;
+use tokio::{self, stream::StreamExt};
 
-// Register some files to be tailed, whether they currently exist or not.
-lines.add_file("some/file.log").await?;
-lines.add_file("/some/other/file.log").await?;
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    let mut lines = MuxedLines::new();
 
-// Wait for `LineSet` event, which contains a batch of lines captured for a
-// given source path.
-while let Some(lineset) = lines.next().await {
-    let source = lineset.source().display();
+    // Register some files to be tailed, whether they currently exist or not.
+    lines.add_file("some/file.log").await?;
+    lines.add_file("/some/other/file.log").await?;
 
-    for line in lineset.iter() {
-        println!("source: {}, line: {}", source, line);
+    // Wait for `LineSet` event, which contains a batch of lines captured for a
+    // given source path.
+    while let Some(lineset) = lines.next().await {
+        let source = lineset.source().display();
+
+        for line in lineset.iter() {
+            println!("source: {}, line: {}", source, line);
+        }
     }
 }
 ```

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -6,7 +6,7 @@
 //! The files could be present or not, but assume some filesystem operations
 //! will eventually be applied to them in order to generate events.
 
-use futures_util::stream::StreamExt;
+use tokio::stream::StreamExt;
 use tokio;
 
 use linemux::MuxedEvents;

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -6,13 +6,11 @@
 //! The files could be present or not, but assume some filesystem operations
 //! will eventually be applied to them in order to generate events.
 
-use tokio::stream::StreamExt;
-use tokio;
-
 use linemux::MuxedEvents;
+use tokio::{self, stream::StreamExt};
 
-#[tokio::main(threaded_scheduler)]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+pub async fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
     let mut events = MuxedEvents::new()?;

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -8,13 +8,11 @@
 
 use std::time::Duration;
 
-use tokio::stream::StreamExt;
-use tokio;
-
 use linemux::MuxedLines;
+use tokio::{self, stream::StreamExt};
 
-#[tokio::main(threaded_scheduler)]
-pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[tokio::main]
+pub async fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
     let mut events = MuxedLines::new()?;

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -8,7 +8,7 @@
 
 use std::time::Duration;
 
-use futures_util::stream::StreamExt;
+use tokio::stream::StreamExt;
 use tokio;
 
 use linemux::MuxedLines;

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,8 +9,8 @@ use std::pin::Pin;
 use std::task;
 
 use futures_util::ready;
-use tokio::stream::Stream;
 use notify;
+use tokio::stream::Stream;
 use tokio::sync::mpsc;
 
 type EventStream = mpsc::UnboundedReceiver<Result<notify::Event, notify::Error>>;

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::task;
 
 use futures_util::ready;
-use futures_util::stream::Stream as FuturesStream;
+use tokio::stream::Stream;
 use notify;
 use tokio::sync::mpsc;
 
@@ -222,7 +222,7 @@ impl MuxedEvents {
     }
 }
 
-impl FuturesStream for MuxedEvents {
+impl Stream for MuxedEvents {
     type Item = io::Result<notify::Event>;
 
     fn poll_next(
@@ -290,12 +290,12 @@ mod tests {
     use super::absolutify;
     use super::MuxedEvents;
     use crate::events::notify_to_io_error;
-    use futures_util::stream::StreamExt;
     use notify;
     use std::time::Duration;
     use tempdir::TempDir;
     use tokio;
     use tokio::fs::File;
+    use tokio::stream::StreamExt;
 
     #[test]
     fn test_add_directory() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,29 +6,28 @@
 //! ## Example
 //!
 //! ```rust,no_run
-//! # use tokio::stream::StreamExt;
-//! # use linemux::MuxedLines;
-//! # use std::io;
-//! # use std::path::Path;
-//! #
-//! # async fn dox() -> io::Result<()> {
-//! let mut lines = MuxedLines::new()?;
+//! use linemux::MuxedLines;
+//! use tokio::{self, stream::StreamExt};
 //!
-//! // Register some files to be tailed, whether they currently exist or not.
-//! lines.add_file("some/file.log").await?;
-//! lines.add_file("/some/other/file.log").await?;
+//! #[tokio::main]
+//! async fn main() -> std::io::Result<()> {
+//!     let mut lines = MuxedLines::new()?;
 //!
-//! // Wait for `LineSet` event, which contains a batch of lines captured for a
-//! // given source path.
-//! while let Some(Ok(lineset)) = lines.next().await {
-//!     let source = lineset.source().display();
+//!     // Register some files to be tailed, whether they currently exist or not.
+//!     lines.add_file("some/file.log").await?;
+//!     lines.add_file("/some/other/file.log").await?;
 //!
-//!     for line in lineset.iter() {
-//!         println!("source: {}, line: {}", source, line);
+//!     // Wait for `LineSet` event, which contains a batch of lines captured for a
+//!     // given source path.
+//!     while let Some(Ok(lineset)) = lines.next().await {
+//!         let source = lineset.source().display();
+//!
+//!         for line in lineset.iter() {
+//!             println!("source: {}, line: {}", source, line);
+//!         }
 //!     }
+//!     Ok(())
 //! }
-//! # Ok(())
-//! # }
 //! ```
 //!
 //! ## Caveats

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! ## Example
 //!
 //! ```rust,no_run
-//! # use futures_util::stream::StreamExt;
+//! # use tokio::stream::StreamExt;
 //! # use linemux::MuxedLines;
 //! # use std::io;
 //! # use std::path::Path;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -2,12 +2,12 @@
 
 use std::collections::{HashMap, HashSet};
 use std::fmt;
+use std::future::Future;
 use std::io;
 use std::iter::IntoIterator;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::slice::Iter;
-
-use std::future::Future;
 use std::task;
 
 use futures_util::ready;
@@ -15,8 +15,6 @@ use pin_project_lite::pin_project;
 use tokio::fs::{metadata, File};
 use tokio::io::{AsyncBufReadExt, BufReader, Lines};
 use tokio::stream::Stream;
-
-use std::pin::Pin;
 
 type LineReader = Lines<BufReader<File>>;
 


### PR DESCRIPTION
Removes unused crates/version requirements, and makes the examples in docs easier to read.

Also adds badges, license info to README.