### PR TITLE
reader: yield each line separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,10 @@ async fn main() -> std::io::Result<()> {
     lines.add_file("some/file.log").await?;
     lines.add_file("/some/other/file.log").await?;
 
-    // Wait for `LineSet` event, which contains a batch of lines captured for a
-    // given source path.
-    while let Some(lineset) = lines.next().await {
-        let source = lineset.source().display();
-
-        for line in lineset.iter() {
-            println!("source: {}, line: {}", source, line);
-        }
+    // Wait for `Line` event, which contains a the line captured for a given
+    // source path.
+    while let Some(Ok(line)) = lines.next().await {
+        println!("source: {}, line: {}", line.source().display(), line.line());
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ async fn main() -> std::io::Result<()> {
     lines.add_file("some/file.log").await?;
     lines.add_file("/some/other/file.log").await?;
 
-    // Wait for `Line` event, which contains a the line captured for a given
+    // Wait for `Line` event, which contains the line captured for a given
     // source path.
     while let Some(Ok(line)) = lines.next().await {
         println!("source: {}, line: {}", line.source().display(), line.line());

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -6,8 +6,6 @@
 //! The files could be present or not, but assume some data will eventually be
 //! be written to them in order to generate lines.
 
-use std::time::Duration;
-
 use linemux::MuxedLines;
 use tokio::{self, stream::StreamExt};
 
@@ -15,20 +13,14 @@ use tokio::{self, stream::StreamExt};
 pub async fn main() -> std::io::Result<()> {
     let args: Vec<String> = std::env::args().skip(1).collect();
 
-    let mut events = MuxedLines::new()?;
+    let mut lines = MuxedLines::new()?;
 
     for f in args {
-        events.add_file(&f).await?;
+        lines.add_file(&f).await?;
     }
 
-    while let Some(Ok(lineset)) = events.next().await {
-        let source = lineset.source().display();
-
-        for line in lineset.iter() {
-            println!("({}) {}", source, line);
-        }
-
-        tokio::time::delay_for(Duration::from_secs(1)).await;
+    while let Some(Ok(line)) = lines.next().await {
+        println!("({}) {}", line.source().display(), line.line());
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@
 //!     lines.add_file("some/file.log").await?;
 //!     lines.add_file("/some/other/file.log").await?;
 //!
-//!     // Wait for `Line` event, which contains a batch of lines captured for a
-//!     // given source path.
+//!     // Wait for `Line` event, which contains the line captured for a given
+//!     // source path.
 //!     while let Some(Ok(line)) = lines.next().await {
 //!         println!("source: {}, line: {}", line.source().display(), line.line());
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,14 +17,10 @@
 //!     lines.add_file("some/file.log").await?;
 //!     lines.add_file("/some/other/file.log").await?;
 //!
-//!     // Wait for `LineSet` event, which contains a batch of lines captured for a
+//!     // Wait for `Line` event, which contains a batch of lines captured for a
 //!     // given source path.
-//!     while let Some(Ok(lineset)) = lines.next().await {
-//!         let source = lineset.source().display();
-//!
-//!         for line in lineset.iter() {
-//!             println!("source: {}, line: {}", source, line);
-//!         }
+//!     while let Some(Ok(line)) = lines.next().await {
+//!         println!("source: {}, line: {}", line.source().display(), line.line());
 //!     }
 //!     Ok(())
 //! }
@@ -42,4 +38,4 @@ mod events;
 mod reader;
 
 pub use events::MuxedEvents;
-pub use reader::{LineSet, MuxedLines};
+pub use reader::{Line, MuxedLines};


### PR DESCRIPTION
Replaces `LineSet` with `Line` which gets propagated for every
`MuxedLines::next`, instead of collecting as many lines as possible and
then propagating that as a vector.

This is no less performant than the previous method, and the API is
arguably simpler by not having to iterate within an iterator.

Closes #5