### PR TITLE
reader: add Send + Sync to MuxedLines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Added
+- Add `Send` + `Sync` to `MuxedLines`.
+
 ## [0.1.0] - 2020-04-10
 
 ### Added


### PR DESCRIPTION
Useful autotraits were lost when introducing the anonymous async/await
Future. `Send` and `Sync` just needed to be applied to the trait object.