### PR TITLE
test: disable macro features for non-test builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@ pin-project-lite = "0.1"
 tokio = { version = "0.2", features = ["fs", "io-util", "stream", "sync", "time"] }
 
 [dev-dependencies]
+doc-comment = "0.3"
 tempdir = "0.3"
 tokio = { version = "0.2", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ travis-ci = { repository = "jmagnuson/linemux", branch = "master" }
 codecov = { repository = "jmagnuson/linemux", branch = "master", service = "github" }
 
 [dependencies]
-futures-util = "0.3"
+futures-util = { version = "0.3", default-features = false, features = ["std"] }
 notify = "5.0.0-pre.2"
 pin-project-lite = "0.1"
-tokio = { version = "0.2", features = ["fs", "io-util", "macros", "stream", "sync", "time"] }
+tokio = { version = "0.2", features = ["fs", "io-util", "stream", "sync", "time"] }
 
 [dev-dependencies]
 tempdir = "0.3"
+tokio = { version = "0.2", features = ["macros"] }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ linemux = "0.1"
 
 ## Example
 
-```rust
+```rust,no_run
 use linemux::MuxedLines;
 use tokio::stream::StreamExt;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Example
 //!
-//! ```rust,no_run
+//! ```no_run
 //! use linemux::MuxedLines;
 //! use tokio::stream::StreamExt;
 //!
@@ -39,3 +39,6 @@ mod reader;
 
 pub use events::MuxedEvents;
 pub use reader::{Line, MuxedLines};
+
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -404,7 +404,6 @@ mod tests {
     use super::*;
     use std::time::Duration;
     use tempdir::TempDir;
-    use tokio;
     use tokio::fs::File;
     use tokio::io::AsyncWriteExt;
     use tokio::stream::StreamExt;
@@ -549,12 +548,11 @@ mod tests {
             .await
             .expect("Failed to create file");
 
-        tokio::select!(
-            _event = lines.next() => {
-                panic!("Should not be any lines yet");
-            }
-            _ = tokio::time::delay_for(Duration::from_millis(100)) => {
-            }
+        assert!(
+            timeout(Duration::from_millis(100), lines.next())
+                .await
+                .is_err(),
+            "Should not be any lines yet",
         );
 
         // Now the files should be readable


### PR DESCRIPTION
Moves the tokio's `macros` feature flag to `dev-dependencies` since it
is only needed for tests, and removes flags from futures-util which
would otherwise pull in `proc-macro2` and needlessly increase build
times.