### PR TITLE
reader: replace `handle_event` with Poll fn 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+- Fix issue where `MuxedLines::add_file` can panic if called while in transient
+  `StreamState`.
+
 ## [0.1.1] - 2020-04-16
 
 ### Added


### PR DESCRIPTION
This allows `MuxedLines` to maintain its `Inner` field, and fixes an
issue where calling `add_file` can panic if in a transient
`StreamState`.

Fixes #13.