### PR TITLE
event: force unwatch on `Remove(File)` event 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ### Fixed
 - Fix issue where `MuxedLines::add_file` can panic if called while in transient
   `StreamState`.
+- Force unwatch on `Remove(File)` event to fix potential race with underlying
+  filesystem state.
 
 ## [0.1.1] - 2020-04-16
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ codecov = { repository = "jmagnuson/linemux", branch = "master", service = "gith
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
-notify = "5.0.0-pre.2"
+notify = "5.0.0-pre.4"
 pin-project-lite = "0.1"
 tokio = { version = "0.2", features = ["fs", "io-util", "stream", "sync", "time"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ tokio = { version = "0.2", features = ["fs", "io-util", "stream", "sync", "time"
 
 [dev-dependencies]
 doc-comment = "0.3"
-tempdir = "0.3"
+tempfile = "3.1"
 tokio = { version = "0.2", features = ["macros"] }

--- a/src/events.rs
+++ b/src/events.rs
@@ -289,14 +289,14 @@ mod tests {
     use super::MuxedEvents;
     use crate::events::notify_to_io_error;
     use std::time::Duration;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::stream::StreamExt;
     use tokio::time::timeout;
 
     #[test]
     fn test_add_directory() {
-        let tmp_dir = TempDir::new("justa-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let mut watcher = MuxedEvents::new().unwrap();
@@ -305,7 +305,7 @@ mod tests {
 
     #[test]
     fn test_add_bad_filename() {
-        let tmp_dir = TempDir::new("justa-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let mut watcher = MuxedEvents::new().unwrap();
@@ -322,7 +322,7 @@ mod tests {
     async fn test_add_missing_files() {
         use tokio::io::AsyncWriteExt;
 
-        let tmp_dir = TempDir::new("missing-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
         let pathclone = absolutify(tmp_dir_path, false).unwrap();
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -189,7 +189,13 @@ impl MuxedEvents {
 
         // TODO: properly handle any errors encountered adding/removing stuff
         paths.retain(|path| {
-            let path_exists = path.exists();
+            let path_exists =
+                if let notify::EventKind::Remove(notify::event::RemoveKind::File) = &event.kind {
+                    // Fixes a potential race when detecting file rotations.
+                    false
+                } else {
+                    path.exists()
+                };
 
             // TODO: could be more intelligent/performant by checking event types
             if path_exists && self.pending_watched_files.contains(path) {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -486,7 +486,7 @@ impl Stream for MuxedLines {
 mod tests {
     use super::*;
     use std::time::Duration;
-    use tempdir::TempDir;
+    use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::io::AsyncWriteExt;
     use tokio::stream::StreamExt;
@@ -530,7 +530,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_inner_fns() {
-        let dir = TempDir::new("some-inner-filedir").unwrap();
+        let dir = tempdir().unwrap();
         let source_path = dir.path().join("foo.txt");
 
         let mut inner = Inner::new();
@@ -581,7 +581,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_directory() {
-        let tmp_dir = TempDir::new("justa-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let mut lines = MuxedLines::new().unwrap();
@@ -590,7 +590,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_add_bad_filename() {
-        let tmp_dir = TempDir::new("justa-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let mut lines = MuxedLines::new().unwrap();
@@ -607,7 +607,7 @@ mod tests {
     async fn test_add_missing_files() {
         use tokio::time::timeout;
 
-        let tmp_dir = TempDir::new("missing-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let file_path1 = tmp_dir_path.join("missing_file1.txt");
@@ -695,7 +695,7 @@ mod tests {
     async fn test_file_rollover() {
         use tokio::time::timeout;
 
-        let tmp_dir = TempDir::new("missing-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let file_path1 = tmp_dir_path.join("missing_file1.txt");
@@ -772,7 +772,7 @@ mod tests {
         use tokio::stream::Stream;
         use tokio::time::timeout;
 
-        let tmp_dir = TempDir::new("missing-filedir").expect("Failed to create tempdir");
+        let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let file_path1 = tmp_dir_path.join("missing_file1.txt");


### PR DESCRIPTION
Fixes potential race with underlying filesystem state.

Fixes #17.

---
Looks like Windows CI is still broken on the transient state test. Would like to get a fix in for that eventually, but shouldn't block this.