### PR TITLE
Update to Tokio 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+- Update Tokio dependency to 1.0
+- Switch to using `futures_util` for Streams
+
 ## [0.1.3] - 2020-11-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ futures-util = { version = "0.3", default-features = false, features = ["std"] }
 notify = "5.0.0-pre.4"
 pin-project-lite = "0.1"
 tokio = { version = "1.0", features = ["fs", "io-util", "sync", "time"] }
-tokio-stream = "0.1"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ codecov = { repository = "jmagnuson/linemux", branch = "master", service = "gith
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 notify = "5.0.0-pre.4"
 pin-project-lite = "0.1"
-tokio = { version = "1", features = ["fs", "io-util", "sync", "time"] }
+tokio = { version = "1.0", features = ["fs", "io-util", "sync", "time"] }
 tokio-stream = "0.1"
 
 [dev-dependencies]
 doc-comment = "0.3"
 tempfile = "3.1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ codecov = { repository = "jmagnuson/linemux", branch = "master", service = "gith
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 notify = "5.0.0-pre.4"
 pin-project-lite = "0.1"
-tokio = { version = "0.2", features = ["fs", "io-util", "stream", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "io-util", "sync", "time"] }
+tokio-stream = "0.1"
 
 [dev-dependencies]
 doc-comment = "0.3"
 tempfile = "3.1"
-tokio = { version = "0.2", features = ["macros"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,9 +9,9 @@ use std::pin::Pin;
 use std::task;
 
 use futures_util::ready;
+use futures_util::stream::Stream;
 use notify::Watcher as NotifyWatcher;
 use tokio::sync::mpsc;
-use tokio_stream::Stream;
 
 type EventStream = mpsc::UnboundedReceiver<Result<notify::Event, notify::Error>>;
 
@@ -332,11 +332,11 @@ mod tests {
     use super::absolutify;
     use super::MuxedEvents;
     use crate::events::notify_to_io_error;
+    use futures_util::stream::StreamExt;
     use std::time::Duration;
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::time::timeout;
-    use tokio_stream::StreamExt;
 
     #[test]
     fn test_add_directory() {

--- a/src/events.rs
+++ b/src/events.rs
@@ -10,8 +10,8 @@ use std::task;
 
 use futures_util::ready;
 use notify::Watcher as NotifyWatcher;
-use tokio::stream::Stream;
 use tokio::sync::mpsc;
+use tokio_stream::Stream;
 
 type EventStream = mpsc::UnboundedReceiver<Result<notify::Event, notify::Error>>;
 
@@ -229,11 +229,11 @@ impl MuxedEvents {
     }
 
     fn __poll_next_event(
-        event_stream: Pin<&mut EventStream>,
+        mut event_stream: Pin<&mut EventStream>,
         cx: &mut task::Context<'_>,
     ) -> task::Poll<Option<io::Result<notify::Event>>> {
         task::Poll::Ready(
-            ready!(event_stream.poll_next(cx)).map(|res| res.map_err(notify_to_io_error)),
+            ready!(event_stream.poll_recv(cx)).map(|res| res.map_err(notify_to_io_error)),
         )
     }
 
@@ -335,8 +335,8 @@ mod tests {
     use std::time::Duration;
     use tempfile::tempdir;
     use tokio::fs::File;
-    use tokio::stream::StreamExt;
     use tokio::time::timeout;
+    use tokio_stream::StreamExt;
 
     #[test]
     fn test_add_directory() {
@@ -413,7 +413,7 @@ mod tests {
         _file1.sync_all().await.unwrap();
         _file1.shutdown().await.unwrap();
         drop(_file1);
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
         // Deleting a file should throw it back into pending
         tokio::fs::remove_file(&file_path1).await.unwrap();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -810,8 +810,8 @@ mod tests {
     #[tokio::test]
     async fn test_ops_in_transient_state() {
         use futures_util::future::poll_fn;
-        use tokio_stream::Stream;
         use tokio::time::timeout;
+        use tokio_stream::Stream;
 
         let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -11,8 +11,8 @@ use std::task;
 use futures_util::ready;
 use pin_project_lite::pin_project;
 use tokio::fs::{metadata, File};
-use tokio::io::{AsyncBufReadExt, BufReader, Lines};
-use tokio::stream::Stream;
+use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, Lines};
+use tokio_stream::Stream;
 
 type LineReader = Lines<BufReader<File>>;
 
@@ -256,18 +256,18 @@ impl MuxedLines {
                 StreamState::ReadLines(paths, ref mut path_index) => {
                     if let Some(path) = paths.get(*path_index) {
                         if let Some(reader) = inner.readers.get_mut(path) {
-                            let res = ready!(Pin::new(reader).poll_next(cx));
+                            let res = ready!(Pin::new(reader).poll_next_line(cx));
 
                             match res {
-                                Some(Ok(line)) => {
+                                Ok(Some(line)) => {
                                     let line = Line {
                                         source: path.clone(),
                                         line,
                                     };
                                     return task::Poll::Ready(Some(Ok(line)).transpose());
                                 }
-                                Some(Err(e)) => (StreamState::Events, Some(Err(e))),
-                                None => {
+                                Err(e) => (StreamState::Events, Some(Err(e))),
+                                Ok(None) => {
                                     // Increase index whether line or not
                                     *path_index += 1;
                                     continue;
@@ -529,7 +529,7 @@ mod tests {
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::io::AsyncWriteExt;
-    use tokio::stream::StreamExt;
+    use tokio_stream::StreamExt;
 
     #[tokio::test]
     async fn test_is_send() {
@@ -683,7 +683,7 @@ mod tests {
         _file1.sync_all().await.unwrap();
         _file1.shutdown().await.unwrap();
         drop(_file1);
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
         let line1 = timeout(Duration::from_millis(100), lines.next())
             .await
             .unwrap()
@@ -700,7 +700,7 @@ mod tests {
         _file2.sync_all().await.unwrap();
         _file2.shutdown().await.unwrap();
         drop(_file2);
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
         {
             let line2 = timeout(Duration::from_millis(100), lines.next())
                 .await
@@ -749,7 +749,7 @@ mod tests {
             .expect("Failed to create file");
         _file1.write_all(b"bar\nbaz\n").await.unwrap();
         _file1.sync_all().await.unwrap();
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
         {
             let line1 = timeout(Duration::from_millis(100), lines.next_line())
                 .await
@@ -791,7 +791,7 @@ mod tests {
         _file1.sync_all().await.unwrap();
         _file1.shutdown().await.unwrap();
         drop(_file1);
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
         {
             let line1 = timeout(Duration::from_millis(100), lines.next())
                 .await
@@ -810,7 +810,7 @@ mod tests {
     #[tokio::test]
     async fn test_ops_in_transient_state() {
         use futures_util::future::poll_fn;
-        use tokio::stream::Stream;
+        use tokio_stream::Stream;
         use tokio::time::timeout;
 
         let tmp_dir = tempdir().unwrap();
@@ -826,7 +826,7 @@ mod tests {
             .expect("Failed to create file");
         _file1.write_all(b"bar\n").await.unwrap();
         _file1.sync_all().await.unwrap();
-        tokio::time::delay_for(Duration::from_millis(100)).await;
+        tokio::time::sleep(Duration::from_millis(100)).await;
 
         let maybe_pending =
             poll_fn(|cx| task::Poll::Ready(Pin::new(&mut lines).poll_next(cx))).await;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -9,10 +9,10 @@ use std::pin::Pin;
 use std::task;
 
 use futures_util::ready;
+use futures_util::stream::Stream;
 use pin_project_lite::pin_project;
 use tokio::fs::{metadata, File};
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, Lines};
-use tokio_stream::Stream;
 
 type LineReader = Lines<BufReader<File>>;
 
@@ -525,11 +525,11 @@ impl Stream for MuxedLines {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures_util::stream::StreamExt;
     use std::time::Duration;
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::io::AsyncWriteExt;
-    use tokio_stream::StreamExt;
 
     #[tokio::test]
     async fn test_is_send() {
@@ -810,8 +810,8 @@ mod tests {
     #[tokio::test]
     async fn test_ops_in_transient_state() {
         use futures_util::future::poll_fn;
+        use futures_util::stream::Stream;
         use tokio::time::timeout;
-        use tokio_stream::Stream;
 
         let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();


### PR DESCRIPTION
This updates the Tokio dependency to 1.0. It doesn't look like much changed for linemux, which is nice. Just a couple things to note:

- Stream stuff was split out to its own crate, `tokio-stream`
- `delay_for()` was renamed to `sleep()`, and a few other things were renamed.

All of the tests run and pass, and I tested this by using it in my own program, which continues to function properly. Of course, that's still a bit limited, so further testing with other use cases would be good.