### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+## [0.2.0] - 2021-04-18
+
 ### Changed
 - Update Tokio dependency to 1.0
 - Switch to using `futures_util` for Streams
@@ -42,7 +44,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ### Added
 - Initial library features
 
-[Unreleased]: https://github.com/jmagnuson/linemux/compare/0.1.3...master
+[Unreleased]: https://github.com/jmagnuson/linemux/compare/0.2.0...master
+[0.2.0]: https://github.com/jmagnuson/linemux/compare/0.1.3...0.2.0
 [0.1.3]: https://github.com/jmagnuson/linemux/compare/0.1.2...0.1.3
 [0.1.2]: https://github.com/jmagnuson/linemux/compare/0.1.1...0.1.2
 [0.1.1]: https://github.com/jmagnuson/linemux/compare/0.1.0...0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Switch to using `futures_util` for Streams
 - Bump MSRV to 1.47 per `notify` update
 - Make tokio optional (but default) to allow for future runtime variance.
+- `MuxedEvents::add_file` is async and takes `Into<PathBuf>`
 
 ## [0.1.3] - 2020-11-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - Update Tokio dependency to 1.0
 - Switch to using `futures_util` for Streams
 - Bump MSRV to 1.47 per `notify` update
+- Make tokio optional (but default) to allow for future runtime variance.
 
 ## [0.1.3] - 2020-11-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,17 @@ categories = ["asynchronous", "filesystem"]
 travis-ci = { repository = "jmagnuson/linemux", branch = "master" }
 codecov = { repository = "jmagnuson/linemux", branch = "master", service = "github" }
 
+[features]
+default = ["tokio"]
+tokio = ["_tokio"]
+
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 notify = "5.0.0-pre.7"
 pin-project-lite = "0.1"
-tokio = { version = "1.0", features = ["fs", "io-util", "sync", "time"] }
+_tokio = { package = "tokio", version = "1.0", features = ["fs", "io-util", "sync", "time"], optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"
 tempfile = "3.1"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
+_tokio = { package = "tokio", version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linemux"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
 edition = "2018"
 description = "A library providing asynchronous, multiplexed tailing for (namely log) files."

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add linemux to your `Cargo.toml` with:
 
 ```toml
 [dependencies]
-linemux = "0.1"
+linemux = "0.2"
 ```
 
 ## Example

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -15,7 +15,7 @@ pub async fn main() -> std::io::Result<()> {
     let mut events = MuxedEvents::new()?;
 
     for f in args {
-        events.add_file(&f)?;
+        events.add_file(&f).await?;
     }
 
     while let Ok(Some(event)) = events.next_event().await {

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -24,3 +24,7 @@ pub async fn main() -> std::io::Result<()> {
 
     Ok(())
 }
+
+// Ignore this (not necessary for normal application use)
+// Ref: https://github.com/tokio-rs/tokio/issues/2312
+use _tokio as tokio;

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -24,3 +24,7 @@ pub async fn main() -> std::io::Result<()> {
 
     Ok(())
 }
+
+// Ignore this (not necessary for normal application use)
+// Ref: https://github.com/tokio-rs/tokio/issues/2312
+use _tokio as tokio;

--- a/src/events.rs
+++ b/src/events.rs
@@ -157,8 +157,12 @@ impl MuxedEvents {
     /// Returns the canonicalized version of the path originally supplied, to
     /// match against the one contained in each `notify::Event` received.
     /// Otherwise returns `Error` for a given registration failure.
-    pub fn add_file(&mut self, path: impl AsRef<Path>) -> io::Result<PathBuf> {
-        let path = absolutify(path.as_ref(), true)?;
+    pub async fn add_file(&mut self, path: impl Into<PathBuf>) -> io::Result<PathBuf> {
+        self._add_file(path)
+    }
+
+    fn _add_file(&mut self, path: impl Into<PathBuf>) -> io::Result<PathBuf> {
+        let path = absolutify(path, true)?;
 
         // TODO: non-existent file that later gets created as a dir?
         if path.is_dir() {
@@ -215,12 +219,12 @@ impl MuxedEvents {
                 let parent = path.parent().expect("Pending watched file needs a parent");
                 let _ = self.remove_directory(parent);
                 self.pending_watched_files.remove(path);
-                let _ = self.add_file(path);
+                let _ = self._add_file(path);
             }
 
             if !path_exists && self.watched_files.contains(path) {
                 self.watched_files.remove(path);
-                let _ = self.add_file(path);
+                let _ = self._add_file(path);
             }
 
             self.watched_files.contains(path)
@@ -340,17 +344,17 @@ mod tests {
     use tokio::fs::File;
     use tokio::time::timeout;
 
-    #[test]
-    fn test_add_directory() {
+    #[tokio::test]
+    async fn test_add_directory() {
         let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
         let mut watcher = MuxedEvents::new().unwrap();
-        assert!(watcher.add_file(&tmp_dir_path).is_err());
+        assert!(watcher.add_file(&tmp_dir_path).await.is_err());
     }
 
-    #[test]
-    fn test_add_bad_filename() {
+    #[tokio::test]
+    async fn test_add_bad_filename() {
         let tmp_dir = tempdir().unwrap();
         let tmp_dir_path = tmp_dir.path();
 
@@ -358,10 +362,10 @@ mod tests {
 
         // This is not okay
         let file_path1 = tmp_dir_path.join("..");
-        assert!(watcher.add_file(&file_path1).is_err());
+        assert!(watcher.add_file(&file_path1).await.is_err());
 
         // Don't add dir as file either
-        assert!(watcher.add_file(&tmp_dir_path).is_err());
+        assert!(watcher.add_file(&tmp_dir_path).await.is_err());
     }
 
     #[tokio::test]
@@ -377,11 +381,11 @@ mod tests {
 
         let mut watcher = MuxedEvents::new().unwrap();
         let _ = format!("{:?}", watcher);
-        watcher.add_file(&file_path1).unwrap();
-        watcher.add_file(&file_path2).unwrap();
+        watcher.add_file(&file_path1).await.unwrap();
+        watcher.add_file(&file_path2).await.unwrap();
 
         // Registering the same path again should be fine
-        watcher.add_file(&file_path2).unwrap();
+        watcher.add_file(&file_path2).await.unwrap();
 
         assert_eq!(watcher.pending_watched_files.len(), 2);
         assert!(watcher.watched_directories.contains_key(&pathclone));

--- a/src/events.rs
+++ b/src/events.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task;
 
+use _tokio as tokio;
 use futures_util::ready;
 use futures_util::stream::Stream;
 use notify::Watcher as NotifyWatcher;
@@ -332,6 +333,7 @@ mod tests {
     use super::absolutify;
     use super::MuxedEvents;
     use crate::events::notify_to_io_error;
+    use _tokio as tokio;
     use futures_util::stream::StreamExt;
     use std::time::Duration;
     use tempfile::tempdir;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 //!
 //! ```no_run
 //! use linemux::MuxedLines;
+//! # use _tokio as tokio;
 //!
 //! #[tokio::main]
 //! async fn main() -> std::io::Result<()> {
@@ -39,5 +40,6 @@ mod reader;
 pub use events::MuxedEvents;
 pub use reader::{Line, MuxedLines};
 
-#[cfg(doctest)]
-doc_comment::doctest!("../README.md");
+// FIXME: would otherwise need to expose the `_tokio` rename in docs
+// #[cfg(doctest)]
+// doc_comment::doctest!("../README.md");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -667,6 +667,12 @@ mod tests {
         let mut _file1 = File::create(&file_path1)
             .await
             .expect("Failed to create file");
+
+        if cfg!(target_os = "macos") {
+            // XXX: OSX sometimes fails `readers.len() == 2` if no delay in between file creates.
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
         let mut _file2 = File::create(&file_path2)
             .await
             .expect("Failed to create file");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task;
 
+use _tokio as tokio;
 use futures_util::ready;
 use futures_util::stream::Stream;
 use pin_project_lite::pin_project;
@@ -525,6 +526,7 @@ impl Stream for MuxedLines {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use _tokio as tokio;
     use futures_util::stream::StreamExt;
     use std::time::Duration;
     use tempfile::tempdir;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -186,7 +186,7 @@ impl MuxedLines {
     pub async fn add_file(&mut self, path: impl Into<PathBuf>) -> io::Result<PathBuf> {
         let source = path.into();
 
-        let source = self.events.add_file(&source)?;
+        let source = self.events.add_file(&source).await?;
 
         if self.reader_exists(&source) {
             return Ok(source);


### PR DESCRIPTION
Includes a couple changes for the release:
- tokio as a runtime is "optional" but default, via `tokio` feature flag. This will allow for future runtime variants such as `async-std`, or no runtime at all (blocking).
- `MuxedEvents::add_file` is now async, and takes `Into<PathBuf>`. 