### PR TITLE
deps: tokio crate renamed to `tokio_`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,15 @@ codecov = { repository = "jmagnuson/linemux", branch = "master", service = "gith
 
 [features]
 default = ["tokio"]
-tokio = ["_tokio"]
+tokio = ["tokio_"]
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 notify = "5.0.0-pre.7"
 pin-project-lite = "0.1"
-_tokio = { package = "tokio", version = "1.0", features = ["fs", "io-util", "sync", "time"], optional = true }
+tokio_ = { package = "tokio", version = "1.0", features = ["fs", "io-util", "sync", "time"], optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"
 tempfile = "3.1"
-_tokio = { package = "tokio", version = "1.0", features = ["macros", "rt-multi-thread"] }
+tokio_ = { package = "tokio", version = "1.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -27,4 +27,4 @@ pub async fn main() -> std::io::Result<()> {
 
 // Ignore this (not necessary for normal application use)
 // Ref: https://github.com/tokio-rs/tokio/issues/2312
-use _tokio as tokio;
+use tokio_ as tokio;

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -27,4 +27,4 @@ pub async fn main() -> std::io::Result<()> {
 
 // Ignore this (not necessary for normal application use)
 // Ref: https://github.com/tokio-rs/tokio/issues/2312
-use _tokio as tokio;
+use tokio_ as tokio;

--- a/src/events.rs
+++ b/src/events.rs
@@ -8,11 +8,11 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task;
 
-use _tokio as tokio;
 use futures_util::ready;
 use futures_util::stream::Stream;
 use notify::Watcher as NotifyWatcher;
 use tokio::sync::mpsc;
+use tokio_ as tokio;
 
 type EventStream = mpsc::UnboundedReceiver<Result<notify::Event, notify::Error>>;
 
@@ -337,12 +337,12 @@ mod tests {
     use super::absolutify;
     use super::MuxedEvents;
     use crate::events::notify_to_io_error;
-    use _tokio as tokio;
     use futures_util::stream::StreamExt;
     use std::time::Duration;
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::time::timeout;
+    use tokio_ as tokio;
 
     #[tokio::test]
     async fn test_add_directory() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```no_run
 //! use linemux::MuxedLines;
-//! # use _tokio as tokio;
+//! # use tokio_ as tokio;
 //!
 //! #[tokio::main]
 //! async fn main() -> std::io::Result<()> {
@@ -40,6 +40,6 @@ mod reader;
 pub use events::MuxedEvents;
 pub use reader::{Line, MuxedLines};
 
-// FIXME: would otherwise need to expose the `_tokio` rename in docs
+// FIXME: would otherwise need to expose the `tokio_` rename in docs
 // #[cfg(doctest)]
 // doc_comment::doctest!("../README.md");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -8,12 +8,12 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::task;
 
-use _tokio as tokio;
 use futures_util::ready;
 use futures_util::stream::Stream;
 use pin_project_lite::pin_project;
 use tokio::fs::{metadata, File};
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, Lines};
+use tokio_ as tokio;
 
 type LineReader = Lines<BufReader<File>>;
 
@@ -526,12 +526,12 @@ impl Stream for MuxedLines {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use _tokio as tokio;
     use futures_util::stream::StreamExt;
     use std::time::Duration;
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::io::AsyncWriteExt;
+    use tokio_ as tokio;
 
     #[tokio::test]
     async fn test_is_send() {


### PR DESCRIPTION
The previously-used `_tokio` was denied by crates.io when attempting to
publish v0.2.0. This naming rule was not known until after tagging, so
v0.2.1 will be the next release published. This name is only used
internally, and thus is not breaking.

Workaround for https://github.com/rust-lang/crates.io/issues/3532.