### PR TITLE
Properly handle renaming to a watched file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+- Properly handle renaming to a watched file, and fix panic when checking
+  nonexistent reader position.
+
 ## [0.2.1] - 2021-04-23
 
 - Marker release only (no functional changes)

--- a/src/events.rs
+++ b/src/events.rs
@@ -206,10 +206,15 @@ impl MuxedEvents {
             let path_exists =
                 if let notify::EventKind::Remove(notify::event::RemoveKind::File) = &event.kind {
                     false
-                } else if let notify::EventKind::Modify(notify::event::ModifyKind::Name(_)) =
-                    &event.kind
+                } else if let notify::EventKind::Modify(notify::event::ModifyKind::Name(
+                    notify::event::RenameMode::From,
+                )) = &event.kind
                 {
-                    false
+                    if cfg!(target_os = "macos") {
+                        path.exists()
+                    } else {
+                        false
+                    }
                 } else {
                     path.exists()
                 };


### PR DESCRIPTION
Previously, `Rename` events were only being considered for file removal
and not creation. At least on Linux, rename operations such as `mv` only
emit `Rename` events, so this must be handled.

Also makes special considerations for OSX, which only emits
`RenameMode::From` events regardless of source/dest. `::From` was
originally mapped to a file removal to prevent a race condition, but I
believe that only applied to Linux targets.

Fixes #36.