### PR TITLE
Tail Files from Either Start or End

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc;
 use tokio_ as tokio;
 
 type EventStream = mpsc::UnboundedReceiver<Result<notify::Event, notify::Error>>;
+type EventStreamSender = mpsc::UnboundedSender<Result<notify::Event, notify::Error>>;
 
 fn notify_to_io_error(e: notify::Error) -> io::Error {
     match e.kind {
@@ -43,6 +44,7 @@ pub struct MuxedEvents {
     /// in for the watched parent directory.
     pending_watched_files: HashSet<PathBuf>,
     event_stream: EventStream,
+    event_stream_sender: EventStreamSender,
 }
 
 impl Debug for MuxedEvents {
@@ -59,6 +61,8 @@ impl MuxedEvents {
     /// Constructs a new `MuxedEvents` instance.
     pub fn new() -> io::Result<Self> {
         let (tx, rx) = mpsc::unbounded_channel();
+        let sender = tx.clone();
+
         let inner: notify::RecommendedWatcher = notify::RecommendedWatcher::new(move |res| {
             // The only way `send` can fail is if the receiver is dropped,
             // and `MuxedEvents` controls both. `unwrap` is not used,
@@ -74,6 +78,7 @@ impl MuxedEvents {
             watched_files: HashSet::new(),
             pending_watched_files: HashSet::new(),
             event_stream: rx,
+            event_stream_sender: sender,
         })
     }
 
@@ -158,10 +163,21 @@ impl MuxedEvents {
     /// match against the one contained in each `notify::Event` received.
     /// Otherwise returns `Error` for a given registration failure.
     pub async fn add_file(&mut self, path: impl Into<PathBuf>) -> io::Result<PathBuf> {
-        self._add_file(path)
+        self._add_file(path, false)
     }
 
-    fn _add_file(&mut self, path: impl Into<PathBuf>) -> io::Result<PathBuf> {
+    /// Adds a given file to the event watch, allowing for files which do not
+    /// yet exist. Once the file is added, an event is immediately created for
+    /// the file to trigger reading it as soon as events are being read.
+    ///
+    /// Returns the canonicalized version of the path originally supplied, to
+    /// match against the one contained in each `notify::Event` received.
+    /// Otherwise returns `Error` for a given registration failure.
+    pub async fn add_file_initial_event(&mut self, path: impl Into<PathBuf>) -> io::Result<PathBuf> {
+        self._add_file(path, true)
+    }
+
+    fn _add_file(&mut self, path: impl Into<PathBuf>, initial_event: bool) -> io::Result<PathBuf> {
         let path = absolutify(path, true)?;
 
         // TODO: non-existent file that later gets created as a dir?
@@ -188,8 +204,21 @@ impl MuxedEvents {
             self.pending_watched_files.insert(path.clone());
         } else {
             Self::watch(&mut self.inner, &path)?;
-
             self.watched_files.insert(path.clone());
+
+            if initial_event {
+                // Send an initial event for this file when requested.
+                // This is useful if we wanted earlier lines in the file than
+                // where it is up to now, and we want those events before the
+                // next time this file is modified.
+                self.event_stream_sender.send(Ok(notify::Event {
+                    attrs: notify::event::EventAttributes::new(),
+                    kind: notify::EventKind::Create(notify::event::CreateKind::File),
+                    paths: vec![path.clone()],
+                })).ok();
+                // Errors here are not anything to worry about, so we .ok();
+                // An error would just mean no one is listening.
+            }
         }
 
         Ok(path)
@@ -223,12 +252,12 @@ impl MuxedEvents {
                 let parent = path.parent().expect("Pending watched file needs a parent");
                 let _ = self.remove_directory(parent);
                 self.pending_watched_files.remove(path);
-                let _ = self._add_file(path);
+                let _ = self._add_file(path, false);
             }
 
             if !path_exists && self.watched_files.contains(path) {
                 self.watched_files.remove(path);
-                let _ = self._add_file(path);
+                let _ = self._add_file(path, false);
             }
 
             self.watched_files.contains(path)

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -167,7 +167,7 @@ impl MuxedLines {
     /// Returns the canonicalized version of the path originally supplied, to
     /// match against the one contained in each `Line` received. Otherwise
     /// returns `io::Error` for a given registration failure.
-    pub async fn add_file(&mut self, path: impl Into<PathBuf>) -> io::Result<PathBuf> {
+    pub async fn add_file(&mut self, path: impl Into<PathBuf>, from_start: bool) -> io::Result<PathBuf> {
         let source = path.into();
 
         let source = self.events.add_file(&source).await?;
@@ -182,7 +182,10 @@ impl MuxedLines {
             // If this fails it's a bug
             assert!(didnt_exist);
         } else {
-            let size = metadata(&source).await?.len();
+            let size = match from_start {
+                true => 0,
+                false => metadata(&source).await?.len(),
+            };
 
             let reader = new_linereader(&source, Some(size)).await?;
 


### PR DESCRIPTION
Completes #46 

This change makes it so that files can be tailed from the start, should the user need that.

It stores a `Sender` for the `notify` events channel, and pushes in an initial event when the file is added and we want to read form start. This ensures that we get the old lines immediately upon reading events.

No idea if these changes match up with how you'd prefer the interface to look, I just took a guess at what seemed appropriate. Feel free to suggest alternative interfaces and I will update the PR.