### PR TITLE
muxed events: update remove events to include paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+- Muxed events: include paths in remove events
+
 ## [0.2.3] - 2021-07-31
 
 ### Fixed


### PR DESCRIPTION
Remove events previously had their associated paths stripped from them.  Now they are included such that consumers can associate the event with the corresponding file that has been removed.