### PR TITLE
deps: update and pin notify to 5.0.0-pre.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ### Changed
 - Muxed events: include paths in remove events
-- Update `notify` to `5.0.0-pre.14` to allow `kqueue` support
+- Update `notify` to `5.0.0-pre.16` to allow `kqueue` support
 - Switch OSX notification backend from `fsevents` to `kqueue`
 - Store `Watcher` as a trait object to allow runtime variance of the
   notification backend.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio = ["tokio_"]
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
-notify = { version = "5.0.0-pre.14", default-features = false, features = ["macos_kqueue"] }
+notify = { version = "=5.0.0-pre.16", default-features = false, features = ["macos_kqueue", "crossbeam-channel"] }
 pin-project-lite = "0.2"
 tokio_ = { package = "tokio", version = "1", features = ["fs", "io-util", "sync", "time"], optional = true }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -60,13 +60,16 @@ impl MuxedEvents {
     /// Constructs a new `MuxedEvents` instance.
     pub fn new() -> io::Result<Self> {
         let (tx, rx) = mpsc::unbounded_channel();
-        let inner: notify::RecommendedWatcher = notify::RecommendedWatcher::new(move |res| {
-            // The only way `send` can fail is if the receiver is dropped,
-            // and `MuxedEvents` controls both. `unwrap` is not used,
-            // however, since `Drop` idiosyncrasies could otherwise result
-            // in a panic.
-            let _ = tx.send(res);
-        })
+        let inner: notify::RecommendedWatcher = notify::RecommendedWatcher::new(
+            move |res| {
+                // The only way `send` can fail is if the receiver is dropped,
+                // and `MuxedEvents` controls both. `unwrap` is not used,
+                // however, since `Drop` idiosyncrasies could otherwise result
+                // in a panic.
+                let _ = tx.send(res);
+            },
+            notify::Config::default(),
+        )
         .map_err(notify_to_io_error)?;
 
         Ok(MuxedEvents {


### PR DESCRIPTION
Looks like `crossbeam-channel` was getting used by default previously,
but now needs to be enabled explicitly in order for `Watcher` to be
`Sync`.

Closes #54.