### PR TITLE
test: fix unit tests for osx

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
Switching from fsevents to kqueue broke some of the unit tests when run on MacOS. The unit tests aren't a great source of confidence anyway, since they so heavily rely on system-level operations. Integration and in-situ testing is better for providing confidence.

This also re-enables osx unit testing in CI.