### PR TITLE
Update notify, MSRV, and edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 - 
 ### Changed
 - Update `notify` to `5.0.0`
+- Bump MSRV from 1.47 to 1.60, to take advantage of `dep:` syntax
 
 ## [0.2.4] - 2022-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ### Added
 - Add `MuxedLines::add_file_from_start`.
+- 
+### Changed
+- Update `notify` to `5.0.0`
 
 ## [0.2.4] - 2022-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ### Changed
 - Update `notify` to `5.0.0`
 - Bump MSRV from 1.47 to 1.60, to take advantage of `dep:` syntax
+- Bump Rust edition to 2021
 
 ## [0.2.4] - 2022-08-15
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "linemux"
 version = "0.2.4"
 authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
-edition = "2018"
+edition = "2021"
 description = "A library providing asynchronous, multiplexed tailing for (namely log) files."
 documentation = "https://docs.rs/linemux"
 repository = "https://github.com/jmagnuson/linemux"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ tokio = ["tokio_"]
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
-notify = { version = "=5.0.0-pre.16", default-features = false, features = ["macos_kqueue", "crossbeam-channel"] }
+notify = { version = "5", default-features = false, features = ["macos_kqueue", "crossbeam-channel"] }
 pin-project-lite = "0.2"
 tokio_ = { package = "tokio", version = "1", features = ["fs", "io-util", "sync", "time"], optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["tail", "log", "watch", "fs", "events"]
 license = "MIT OR Apache-2.0"
 categories = ["asynchronous", "filesystem"]
+rust-version = "1.60"
 
 [badges]
 travis-ci = { repository = "jmagnuson/linemux", branch = "master" }
@@ -17,15 +18,15 @@ codecov = { repository = "jmagnuson/linemux", branch = "master", service = "gith
 
 [features]
 default = ["tokio"]
-tokio = ["tokio_"]
+tokio = ["dep:tokio"]
 
 [dependencies]
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 notify = { version = "5", default-features = false, features = ["macos_kqueue", "crossbeam-channel"] }
 pin-project-lite = "0.2"
-tokio_ = { package = "tokio", version = "1", features = ["fs", "io-util", "sync", "time"], optional = true }
+tokio = { version = "1", features = ["fs", "io-util", "sync", "time"], optional = true }
 
 [dev-dependencies]
 doc-comment = "0.3"
 tempfile = "3.1"
-tokio_ = { package = "tokio", version = "1", features = ["macros", "process", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "process", "rt-multi-thread"] }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ presents itself.
 
 ## Minimum Supported Rust Version (MSRV)
 
-This crate is guaranteed to compile on stable Rust 1.47 and up.
+This crate is guaranteed to compile on stable Rust 1.60 and up.
 
 ## License
 

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -24,7 +24,3 @@ pub async fn main() -> std::io::Result<()> {
 
     Ok(())
 }
-
-// Ignore this (not necessary for normal application use)
-// Ref: https://github.com/tokio-rs/tokio/issues/2312
-use tokio_ as tokio;

--- a/examples/lines.rs
+++ b/examples/lines.rs
@@ -24,7 +24,3 @@ pub async fn main() -> std::io::Result<()> {
 
     Ok(())
 }
-
-// Ignore this (not necessary for normal application use)
-// Ref: https://github.com/tokio-rs/tokio/issues/2312
-use tokio_ as tokio;

--- a/src/events.rs
+++ b/src/events.rs
@@ -12,7 +12,6 @@ use futures_util::ready;
 use futures_util::stream::Stream;
 use notify::Watcher as NotifyWatcher;
 use tokio::sync::mpsc;
-use tokio_ as tokio;
 
 type BoxedWatcher = Box<dyn notify::Watcher + Send + Sync + Unpin + 'static>;
 type EventStream = mpsc::UnboundedReceiver<Result<notify::Event, notify::Error>>;
@@ -387,7 +386,6 @@ mod tests {
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::time::timeout;
-    use tokio_ as tokio;
 
     #[tokio::test]
     async fn test_add_directory() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //!
 //! ```no_run
 //! use linemux::MuxedLines;
-//! # use tokio_ as tokio;
 //!
 //! #[tokio::main]
 //! async fn main() -> std::io::Result<()> {
@@ -40,6 +39,5 @@ mod reader;
 pub use events::MuxedEvents;
 pub use reader::{Line, MuxedLines};
 
-// FIXME: would otherwise need to expose the `tokio_` rename in docs
-// #[cfg(doctest)]
-// doc_comment::doctest!("../README.md");
+#[cfg(doctest)]
+doc_comment::doctest!("../README.md");

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -13,7 +13,6 @@ use futures_util::stream::Stream;
 use pin_project_lite::pin_project;
 use tokio::fs::{metadata, File};
 use tokio::io::{AsyncBufReadExt, AsyncSeekExt, BufReader, Lines};
-use tokio_ as tokio;
 
 type LineReader = Lines<BufReader<File>>;
 
@@ -567,7 +566,6 @@ mod tests {
     use tempfile::tempdir;
     use tokio::fs::File;
     use tokio::io::AsyncWriteExt;
-    use tokio_ as tokio;
 
     #[tokio::test]
     async fn test_is_send() {

--- a/tests/test-logrotate.rs
+++ b/tests/test-logrotate.rs
@@ -42,7 +42,3 @@ pub async fn test_logrotate() {
     assert!(status.unwrap().success());
     assert_eq!(line_vals_expected, line_vals);
 }
-
-// Ignore this (not necessary for normal application use)
-// Ref: https://github.com/tokio-rs/tokio/issues/2312
-use tokio_ as tokio;


### PR DESCRIPTION
Now that notify v5 is released, we can update off the candidate.

Also update the MSRV to 1.60 to clean up the previous `tokio_` terminology (which disambiguated the package from the feature). And update the edition to 2021, at least to take advantage of the v2 resolver by default.