### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+## [0.3.0] - 2022-12-17
+
 ### Added
 - Add `MuxedLines::add_file_from_start`.
-- 
+
 ### Changed
 - Update `notify` to `5.0.0`
 - Bump MSRV from 1.47 to 1.60, to take advantage of `dep:` syntax

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linemux"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["Jon Magnuson <jon.magnuson@gmail.com>"]
 edition = "2021"
 description = "A library providing asynchronous, multiplexed tailing for (namely log) files."

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add linemux to your `Cargo.toml` with:
 
 ```toml
 [dependencies]
-linemux = "0.2"
+linemux = "0.3"
 ```
 
 ## Example

--- a/src/events.rs
+++ b/src/events.rs
@@ -206,7 +206,7 @@ impl MuxedEvents {
                 io::Error::new(io::ErrorKind::InvalidInput, "File needs a parent directory")
             })?;
 
-            self.add_directory(&parent)?;
+            self.add_directory(parent)?;
             self.pending_watched_files.insert(path.clone());
         } else {
             Self::watch(self.inner.as_mut(), &path)?;


### PR DESCRIPTION
Bumps the minor version to account for changes to edition, MSRV, and `notify` versions.