### PR TITLE
add: re-export notifity Event and EventKind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Added
+- Re-export notify `event` module
+
 ## [0.3.0] - 2022-12-17
 
 ### Added
@@ -78,7 +81,8 @@ and this project adheres to [Semantic Versioning](http://semver.org).
 ### Added
 - Initial library features
 
-[Unreleased]: https://github.com/jmagnuson/linemux/compare/0.2.4...master
+[Unreleased]: https://github.com/jmagnuson/linemux/compare/0.3.0...master
+[0.3.0]: https://github.com/jmagnuson/linemux/compare/0.2.4...0.3.0
 [0.2.4]: https://github.com/jmagnuson/linemux/compare/0.2.3...0.2.4
 [0.2.3]: https://github.com/jmagnuson/linemux/compare/0.2.2...0.2.3
 [0.2.2]: https://github.com/jmagnuson/linemux/compare/0.2.1...0.2.2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ mod events;
 mod reader;
 
 pub use events::MuxedEvents;
+pub use notify::event;
 pub use reader::{Line, MuxedLines};
 
 #[cfg(doctest)]


### PR DESCRIPTION
Re-export useful things from the `notify::event` [module](https://docs.rs/notify/5.1.0/notify/event/index.html) so that users of this lib do not have to include `notify` explicitly to handle specific event types.   


Attempts to address https://github.com/jmagnuson/linemux/issues/65