### PR TITLE
doc: fix CI build badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # linemux
 
-[![Build Status](https://img.shields.io/github/workflow/status/jmagnuson/linemux/Test/master)](https://github.com/jmagnuson/linemux/actions)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/jmagnuson/linemux/test.yml?branch=master)](https://github.com/jmagnuson/linemux/actions)
 [![Crate](https://img.shields.io/crates/v/linemux.svg)](https://crates.io/crates/linemux)
 [![API](https://docs.rs/linemux/badge.svg)](https://docs.rs/linemux)
 [![Coverage](https://codecov.io/gh/jmagnuson/linemux/branch/master/graph/badge.svg)](https://codecov.io/gh/jmagnuson/linemux)


### PR DESCRIPTION
Previously:
[![Build Status](https://img.shields.io/github/workflow/status/jmagnuson/linemux/Test/master)](https://github.com/jmagnuson/linemux/actions)
Now:
[![Build Status](https://img.shields.io/github/actions/workflow/status/jmagnuson/linemux/test.yml?branch=master)](https://github.com/jmagnuson/linemux/actions)