### PR TITLE
Add compile_error! if no runtime is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ Add linemux to your `Cargo.toml` with:
 linemux = "0.3"
 ```
 
+### Feature flags
+
+Note that building with `default-features: false` must also be coupled with activating a desired
+runtime (currently just `tokio`, but eventually others will be supported).
+
+- `tokio`: Use the tokio runtime (default).
+
 ## Example
 
 ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,3 +42,6 @@ pub use reader::{Line, MuxedLines};
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");
+
+#[cfg(not(any(feature = "tokio")))]
+compile_error!("At least one runtime feature must be enabled from: [\"tokio\"]");


### PR DESCRIPTION
Rust will still throw compiler errors for all the usages of tokio, but
this at least adds some context to the failures, in plain English.