### PR TITLE
Fix busy-spin when watched_files goes empty mid-stream

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -242,9 +242,17 @@ impl MuxedLines {
         loop {
             let (new_state, maybe_line) = match stream_state {
                 StreamState::Events => {
-                    let event = unwrap_or_continue!(unwrap_or_continue!(ready!(events
-                        .as_mut()
-                        .poll_next(cx))));
+                    let event = match ready!(events.as_mut().poll_next(cx)) {
+                        None => {
+                            // Upstream stream exhausted (e.g. all watches dropped).
+                            // Return end-of-stream instead of `continue`-ing in a
+                            // tight loop without re-registering the waker.
+                            // See https://github.com/jmagnuson/linemux/issues/57
+                            return task::Poll::Ready(Ok(None));
+                        }
+                        Some(Err(_)) => continue,
+                        Some(Ok(event)) => event,
+                    };
                     (
                         StreamState::HandleEvent(event, HandleEventState::new()),
                         None,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -663,6 +663,62 @@ mod tests {
         let _ = format!("{:?}", state);
     }
 
+    // Regression test for https://github.com/jmagnuson/linemux/issues/57.
+    //
+    // Reproduces the precise post-rotation bug state observed in production:
+    // `Inner::readers` is non-empty (so the `is_empty()` early-return at the
+    // top of `poll_next_line` is skipped) while `MuxedEvents::watched_files`
+    // is empty (so `poll_next_event` returns `Ready(Ok(None))`).
+    //
+    // Before this branch's fix, `unwrap_or_continue!` converted that `None`
+    // into `continue` and the inner loop busy-spun forever — no waker was
+    // ever registered. After the fix `poll_next_line` propagates
+    // `Poll::Ready(Ok(None))` and `MuxedLines::next_line` resolves to
+    // `Ok(None)`, letting the caller drive recovery (e.g. re-attaching
+    // watches or restarting).
+    #[tokio::test]
+    async fn regression_no_busy_spin_on_drained_watched_files() {
+        use tokio::time::timeout;
+
+        let dir = tempdir().unwrap();
+        let source_path = dir.path().join("foo.log");
+        {
+            let mut f = File::create(&source_path).await.unwrap();
+            f.write_all(b"existing-line\n").await.unwrap();
+            f.sync_all().await.unwrap();
+            f.shutdown().await.unwrap();
+        }
+
+        // Construct MuxedLines and put it into the bug state by hand:
+        //   * Inner has a reader for `foo.log`  → is_empty() = false
+        //   * MuxedEvents.watched_files is empty → poll_next_event returns
+        //                                          Ready(Ok(None))
+        //   * stream_state defaults to StreamState::Events (transient=false
+        //     under is_transient(), so the early-return at the top of
+        //     poll_next_line would normally fire — but only if
+        //     `MuxedLines::is_empty()` is true. Inner being non-empty keeps
+        //     us out of that branch and into the inner loop.)
+        let mut lines = MuxedLines::new().unwrap();
+        let linereader = new_linereader(&source_path, None).await.unwrap();
+        lines.inner.insert_reader(source_path.clone(), linereader);
+
+        // 500ms is far more than the patched code needs (it resolves in one
+        // poll). On the unpatched 0.3.0 inner loop this future never
+        // completes because no waker is registered.
+        let outcome = timeout(Duration::from_millis(500), lines.next_line()).await;
+
+        assert!(
+            outcome.is_ok(),
+            "next_line() did not resolve within 500ms — busy-spin regression"
+        );
+        let line = outcome.unwrap().expect("next_line() returned an error");
+        assert!(
+            line.is_none(),
+            "expected Ok(None) (end-of-stream) on drained watched_files, got {:?}",
+            line
+        );
+    }
+
     #[tokio::test]
     async fn test_add_directory() {
         let tmp_dir = tempdir().unwrap();


### PR DESCRIPTION
Fixes #76. Related: #57, #17.

## Summary

`MuxedLines::next_line()` busy-spins (100% CPU, no syscalls, no waker registration) when `MuxedEvents::watched_files` becomes empty while `Inner::readers` is still non-empty. See #76 for the full chain analysis and a deployment report (six processes pegged for 21 days with no log lines delivered).

Replaces the `unwrap_or_continue!` chain at `src/reader.rs:245` with an explicit `match` so `Ready(None)` from the underlying stream propagates as `Poll::Ready(Ok(None))` from `poll_next_line` instead of looping. `Some(Err(_)) => continue` preserves the existing "retry on transient error" semantics.

## Changes

- `src/reader.rs` `MuxedLines::poll_next_line`: six-line patch replacing the macro chain with `match`.
- `src/reader.rs` `mod tests`: new `regression_no_busy_spin_on_drained_watched_files` that constructs the exact `(Inner::readers non-empty, MuxedEvents::watched_files empty, StreamState::Events)` state and asserts `next_line()` resolves to `Ok(None)` within 500ms.

## How the regression test was validated

```
$ cargo test regression_no_busy_spin_on_drained_watched_files
test reader::tests::regression_no_busy_spin_on_drained_watched_files ... ok
test result: ok. 1 passed in 0.00s
```

Reverted the `src/reader.rs:245` change to the original `unwrap_or_continue!` chain (kept the test) and re-ran:

```
$ timeout 30 cargo test regression_no_busy_spin_on_drained_watched_files
running 1 test
(no completion — busy spin; harness `timeout` killed at 30s)
```

So the test reliably catches a regression of the same shape.

## Relationship to #57 and #17

Both #57 (Apache rotatelogs, lines stop arriving after rotation) and #17 (`MuxedLines::next() appears to stop relaying changes after a period`) describe symptoms users hit when `handle_event`'s call to `_add_file` fails after a `Remove(File)` and `watched_files` ends up drained — the orphaned reader remains in `Inner::readers`, so the inner loop is reachable.

This PR doesn't fix the underlying "rotation should re-attach watches more robustly" question those two issues are really about — it fixes the *escalation*: when the state ever does occur, callers should see a clean end-of-stream they can recover from, instead of a silently-pegged core. So #57 should stay open for the rotation work; this just removes the trap door.

## Notes

- `unwrap_or!` and `unwrap_or_continue!` macros at the top of `reader.rs` are now unused. Left in place to keep the patch minimal; happy to delete if you'd prefer.
- Branch is on `Galxe/linemux`; we've been running this patch in production for ~24h already (vendored locally before being pushed for review).
